### PR TITLE
feat: support wechat social account with union id

### DIFF
--- a/social/backends/weixin.py
+++ b/social/backends/weixin.py
@@ -13,7 +13,7 @@ from social.exceptions import AuthCanceled, AuthUnknownError
 class WeixinOAuth2(BaseOAuth2):
     """Weixin OAuth authentication backend"""
     name = 'weixin'
-    ID_KEY = 'openid'
+    ID_KEY = 'unionid'
     AUTHORIZATION_URL = 'https://open.weixin.qq.com/connect/qrconnect'
     ACCESS_TOKEN_URL = 'https://api.weixin.qq.com/sns/oauth2/access_token'
     ACCESS_TOKEN_METHOD = 'POST'
@@ -22,6 +22,10 @@ class WeixinOAuth2(BaseOAuth2):
         ('nickname', 'username'),
         ('headimgurl', 'profile_image_url'),
     ]
+
+    @property
+    def scope(self):
+        return self.setting('scope', 'snsapi_login')
 
     def get_user_details(self, response):
         """Return user details from Weixin. API URL is:
@@ -39,7 +43,7 @@ class WeixinOAuth2(BaseOAuth2):
     def user_data(self, access_token, *args, **kwargs):
         data = self.get_json('https://api.weixin.qq.com/sns/userinfo', params={
             'access_token': access_token,
-            'openid': kwargs['response']['openid']
+            'unionid': kwargs['response']['unionid']
         })
         nickname = data.get('nickname')
         if nickname:
@@ -53,7 +57,8 @@ class WeixinOAuth2(BaseOAuth2):
         appid, secret = self.get_key_and_secret()
         params = {
             'appid': appid,
-            'redirect_uri': self.get_redirect_uri(state)
+            'redirect_uri': self.get_redirect_uri(state),
+            'scope': self.scope
         }
         if self.STATE_PARAMETER and state:
             params['state'] = state
@@ -111,7 +116,7 @@ class WeixinOAuth2APP(WeixinOAuth2):
     Can't use in web, only in weixin app
     """
     name = 'weixinapp'
-    ID_KEY = 'openid'
+    ID_KEY = 'unionid'
     AUTHORIZATION_URL = 'https://open.weixin.qq.com/connect/oauth2/authorize'
     ACCESS_TOKEN_URL = 'https://api.weixin.qq.com/sns/oauth2/access_token'
     ACCESS_TOKEN_METHOD = 'POST'

--- a/social/pipeline/social_auth.py
+++ b/social/pipeline/social_auth.py
@@ -14,9 +14,13 @@ def auth_allowed(backend, details, response, *args, **kwargs):
     if not backend.auth_allowed(response, details):
         raise AuthForbidden(backend)
 
+def fix_weixin_provider(provider):
+    if provider == 'weixinapp':
+        provider = 'weixin'
+    return provider
 
 def social_user(backend, uid, user=None, *args, **kwargs):
-    provider = backend.name
+    provider = fix_weixin_provider(backend.name)
     social = backend.strategy.storage.user.get_social_auth(provider, uid)
     if social:
         if user and social.user != user:
@@ -29,12 +33,12 @@ def social_user(backend, uid, user=None, *args, **kwargs):
             'is_new': user is None,
             'new_association': social is None}
 
-
 def associate_user(backend, uid, user=None, social=None, *args, **kwargs):
     if user and not social:
         try:
+            provider = fix_weixin_provider(backend.name)
             social = backend.strategy.storage.user.create_social_auth(
-                user, uid, backend.name
+                user, uid, provider
             )
         except Exception as err:
             if not backend.strategy.storage.is_integrity_error(err):


### PR DESCRIPTION
This commit applied with the following changes:
  - Changes the associatation key type to the user which is the WeChat unionid
  - Fix the missing scope parameter while aquiring token against WeChat server
  - Hack the data persistence layer in order to unify the WeChat client and others
In order to use this old backend, you should configure your python application as
the following(for instance, django website):
  - enable WeixinOAuth2, WeixinOAuth2APP backends in you application.
  - setup scope for each auth backend in other settings, e.g. "scope": "snsapi_userinfo"
  - make sure WeixinOAuth2APP is invisible to user in you view
  - change you auth url dynamiclly by javascript, e.g.
----
    let documentReadyStateCheck = setInterval(() => {
        if (document.readyState === 'complete') {
            clearInterval(documentReadyStateCheck);
            let agent = navigator.userAgent.toLowerCase();
            let providerUrl = '/auth/login/weixinapp/?auth_entry=login&next=%2Fdashboard';
            if (/micromessenger/.test(agent)) {
                document.getElementById('oa2-weixin')
                        .setAttribute('data-provider-url', providerUrl);
            }
        }
    }, 100);
----